### PR TITLE
features/metadata: Add MetadataExtractor for SAF Uri metadata (EXIF + metadata-extractor)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,6 +36,8 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewmodel.ktx)
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.exifinterface)
+    implementation(libs.metadata.extractor)
 
     implementation(libs.kotlinx.coroutines.android)
 

--- a/app/src/main/java/com/example/octofit/features/metadata/data/MetadataEntry.kt
+++ b/app/src/main/java/com/example/octofit/features/metadata/data/MetadataEntry.kt
@@ -1,0 +1,7 @@
+package com.example.octofit.features.metadata.data
+
+data class MetadataEntry(
+    val key: String,
+    val value: String,
+    val sourceTag: String,
+)

--- a/app/src/main/java/com/example/octofit/features/metadata/data/MetadataExtractor.kt
+++ b/app/src/main/java/com/example/octofit/features/metadata/data/MetadataExtractor.kt
@@ -1,0 +1,142 @@
+package com.example.octofit.features.metadata.data
+
+import android.content.ContentResolver
+import android.content.Context
+import android.net.Uri
+import android.webkit.MimeTypeMap
+import androidx.exifinterface.media.ExifInterface
+import com.drew.imaging.ImageMetadataReader
+import com.drew.imaging.ImageProcessingException
+import com.drew.metadata.Directory
+import com.drew.metadata.Metadata
+import com.drew.metadata.Tag
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.BufferedInputStream
+import java.io.IOException
+import java.io.InputStream
+
+class MetadataExtractor(
+    private val appContext: Context,
+) {
+    suspend fun extract(uri: Uri): List<MetadataEntry> = withContext(Dispatchers.IO) {
+        val contentResolver = appContext.contentResolver
+        val entries = mutableListOf<MetadataEntry>()
+
+        val mimeType = contentResolver.getType(uri)
+        val isExifCapable = isExifCapable(mimeType, uri)
+        if (isExifCapable) {
+            entries += readExif(contentResolver, uri)
+        }
+
+        entries += readMetadataExtractor(contentResolver, uri)
+
+        entries
+            .distinctBy { "${it.key}:${it.value}:${it.sourceTag}" }
+            .sortedWith(compareBy({ it.key }, { it.sourceTag }))
+    }
+
+    private fun isExifCapable(mimeType: String?, uri: Uri): Boolean {
+        if (mimeType == null) {
+            val extension = MimeTypeMap.getFileExtensionFromUrl(uri.toString()).lowercase()
+            return extension in setOf("jpg", "jpeg", "tif", "tiff", "webp", "png", "heic", "heif")
+        }
+        return mimeType.startsWith("image/") || mimeType == "application/octet-stream"
+    }
+
+    private fun readExif(
+        contentResolver: ContentResolver,
+        uri: Uri,
+    ): List<MetadataEntry> {
+        return contentResolver.openInputStream(uri)?.use { input ->
+            val exif = ExifInterface(input)
+            val entries = mutableListOf<MetadataEntry>()
+            for (tag in EXIF_TAGS) {
+                exif.getAttribute(tag)?.let { value ->
+                    if (value.isNotBlank()) {
+                        entries += MetadataEntry(
+                            key = tag,
+                            value = value,
+                            sourceTag = "EXIF:$tag",
+                        )
+                    }
+                }
+            }
+            entries
+        } ?: emptyList()
+    }
+
+    private fun readMetadataExtractor(
+        contentResolver: ContentResolver,
+        uri: Uri,
+    ): List<MetadataEntry> {
+        return contentResolver.openInputStream(uri)?.use { input ->
+            val safeStream = BufferedInputStream(input)
+            safeStream.mark(STREAM_MARK_LIMIT)
+            val metadata = try {
+                ImageMetadataReader.readMetadata(safeStream)
+            } catch (error: ImageProcessingException) {
+                return emptyList()
+            } catch (error: IOException) {
+                return emptyList()
+            } catch (error: RuntimeException) {
+                return emptyList()
+            }
+            metadata.toEntries()
+        } ?: emptyList()
+    }
+
+    private fun Metadata.toEntries(): List<MetadataEntry> {
+        val entries = mutableListOf<MetadataEntry>()
+        for (directory in directories) {
+            entries += directory.toEntries()
+        }
+        return entries
+    }
+
+    private fun Directory.toEntries(): List<MetadataEntry> {
+        val directoryName = name
+        val entries = mutableListOf<MetadataEntry>()
+        for (tag in tags) {
+            val value = safeTagValue(tag)
+            if (!value.isNullOrBlank()) {
+                entries += MetadataEntry(
+                    key = tag.tagName,
+                    value = value,
+                    sourceTag = directoryName,
+                )
+            }
+        }
+        return entries
+    }
+
+    private fun safeTagValue(tag: Tag): String? = try {
+        tag.description
+    } catch (error: RuntimeException) {
+        null
+    }
+
+    companion object {
+        private const val STREAM_MARK_LIMIT = 512 * 1024
+        private val EXIF_TAGS = listOf(
+            ExifInterface.TAG_DATETIME,
+            ExifInterface.TAG_DATETIME_ORIGINAL,
+            ExifInterface.TAG_MAKE,
+            ExifInterface.TAG_MODEL,
+            ExifInterface.TAG_SOFTWARE,
+            ExifInterface.TAG_ORIENTATION,
+            ExifInterface.TAG_IMAGE_WIDTH,
+            ExifInterface.TAG_IMAGE_LENGTH,
+            ExifInterface.TAG_F_NUMBER,
+            ExifInterface.TAG_FOCAL_LENGTH,
+            ExifInterface.TAG_EXPOSURE_TIME,
+            ExifInterface.TAG_ISO_SPEED_RATINGS,
+            ExifInterface.TAG_APERTURE_VALUE,
+            ExifInterface.TAG_SHUTTER_SPEED_VALUE,
+            ExifInterface.TAG_WHITE_BALANCE,
+            ExifInterface.TAG_GPS_LATITUDE,
+            ExifInterface.TAG_GPS_LONGITUDE,
+            ExifInterface.TAG_GPS_ALTITUDE,
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,8 @@ lifecycle = "2.8.6"
 activityCompose = "1.9.2"
 composeBom = "2024.10.00"
 coroutines = "1.9.0"
+exif = "1.3.7"
+metadataExtractor = "2.19.0"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -20,6 +22,8 @@ androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-ru
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
 
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
+androidx-exifinterface = { module = "androidx.exifinterface:exifinterface", version.ref = "exif" }
+metadata-extractor = { module = "com.drewnoakes:metadata-extractor", version.ref = "metadataExtractor" }
 
 compose-bom = { module = "androidx.compose:compose-bom", version.ref = "composeBom" }
 compose-ui = { module = "androidx.compose.ui:ui" }


### PR DESCRIPTION
### Motivation
- Provide a single, robust layer to extract metadata from Storage Access Framework `Uri`s for UI display.
- Support EXIF-capable formats with `ExifInterface` and broader metadata (IPTC/XMP, non-JPEG) with the Drew Noakes `metadata-extractor` library.
- Normalize diverse metadata into a simple model so the UI and ViewModel can consume a consistent shape (`key`, `value`, `sourceTag`).
- Be defensive against large files and malformed metadata to avoid crashes and OOMs in production.

### Description
- Add `MetadataEntry` data class as the normalized metadata model returned to the UI.
- Add `MetadataExtractor` class with `suspend fun extract(uri: Uri): List<MetadataEntry>` which uses `ContentResolver.openInputStream` and accepts SAF `Uri`s.
- Read EXIF tags with `ExifInterface` for EXIF-capable types and use `ImageMetadataReader` from `metadata-extractor` for broader formats and directories.
- Include defensive measures: `BufferedInputStream` with a `mark`/limit (`STREAM_MARK_LIMIT`), try/catch guards around parser calls and `safeTagValue` to ignore malformed tags, plus deduplication and stable sorting of results.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e37c28330832c9c1fd6611ee86761)