### PR TITLE
Add image metadata Compose screen with picker, search, expandable sections, and export

### DIFF
--- a/app/src/main/java/com/example/octofit/MainActivity.kt
+++ b/app/src/main/java/com/example/octofit/MainActivity.kt
@@ -3,24 +3,10 @@ package com.example.octofit
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.octofit.core.ui.theme.OctofitTheme
-import com.example.octofit.features.metadata.MetadataUiState
-import com.example.octofit.features.metadata.MetadataViewModel
+import com.example.octofit.features.metadata.ui.MetadataScreen
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -32,38 +18,5 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
-    }
-}
-
-@Composable
-private fun MetadataScreen(
-    viewModel: MetadataViewModel = viewModel(),
-) {
-    val uiState by viewModel.state.collectAsStateWithLifecycle()
-
-    MetadataContent(
-        uiState = uiState,
-    )
-}
-
-@Composable
-private fun MetadataContent(
-    uiState: MetadataUiState,
-) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(PaddingValues(24.dp)),
-        verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
-        horizontalAlignment = Alignment.Start,
-    ) {
-        Text(
-            text = "App version: ${uiState.appVersion}",
-            style = MaterialTheme.typography.titleMedium,
-        )
-        Text(
-            text = "Metadata sync: ${uiState.lastSyncLabel}",
-            style = MaterialTheme.typography.bodyMedium,
-        )
     }
 }

--- a/app/src/main/java/com/example/octofit/features/metadata/MetadataUiState.kt
+++ b/app/src/main/java/com/example/octofit/features/metadata/MetadataUiState.kt
@@ -2,10 +2,22 @@ package com.example.octofit.features.metadata
 
 import androidx.compose.runtime.Immutable
 import com.example.octofit.core.ui.UiState
+import com.example.octofit.features.metadata.data.MetadataEntry
 
 @Immutable
 data class MetadataUiState(
-    val appVersion: String,
-    val lastSyncLabel: String,
-    val isRefreshing: Boolean,
+    val isLoading: Boolean,
+    val errorMessage: String?,
+    val metadataEntries: List<MetadataEntry>,
+    val searchQuery: String,
+    val sections: List<MetadataSectionUiState>,
+    val expandedSectionIds: Set<String>,
 ) : UiState
+
+@Immutable
+data class MetadataSectionUiState(
+    val id: String,
+    val title: String,
+    val entries: List<MetadataEntry>,
+    val isExpanded: Boolean,
+)

--- a/app/src/main/java/com/example/octofit/features/metadata/MetadataViewModel.kt
+++ b/app/src/main/java/com/example/octofit/features/metadata/MetadataViewModel.kt
@@ -1,21 +1,125 @@
 package com.example.octofit.features.metadata
 
+import android.app.Application
+import android.net.Uri
+import androidx.lifecycle.viewModelScope
 import com.example.octofit.core.ui.BaseViewModel
+import com.example.octofit.features.metadata.data.MetadataEntry
+import com.example.octofit.features.metadata.data.MetadataExtractor
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import org.json.JSONArray
+import org.json.JSONObject
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 
-class MetadataViewModel : BaseViewModel<MetadataUiState>(
+class MetadataViewModel(
+    application: Application,
+) : BaseViewModel<MetadataUiState>(
     initialState = MetadataUiState(
-        appVersion = "1.0.0",
-        lastSyncLabel = "Never",
-        isRefreshing = false,
+        isLoading = false,
+        errorMessage = null,
+        metadataEntries = emptyList(),
+        searchQuery = "",
+        sections = emptyList(),
+        expandedSectionIds = emptySet(),
     ),
 ) {
-    fun updateMetadata(appVersion: String, lastSyncLabel: String, isRefreshing: Boolean) {
+    private val extractor = MetadataExtractor(application.applicationContext)
+    private var loadJob: Job? = null
+
+    fun onImageSelected(uri: Uri) {
+        loadJob?.cancel()
         updateState {
-            copy(
-                appVersion = appVersion,
-                lastSyncLabel = lastSyncLabel,
-                isRefreshing = isRefreshing,
+            copy(isLoading = true, errorMessage = null)
+        }
+        loadJob = viewModelScope.launch {
+            try {
+                val entries = extractor.extract(uri)
+                updateState { buildState(entries = entries) }
+            } catch (error: Exception) {
+                updateState {
+                    copy(
+                        isLoading = false,
+                        errorMessage = "Unable to read metadata. Please try a different image.",
+                    )
+                }
+            }
+        }
+    }
+
+    fun onSearchQueryChange(query: String) {
+        updateState { buildState(searchQuery = query) }
+    }
+
+    fun onToggleSection(sectionId: String) {
+        updateState {
+            val updated = expandedSectionIds.toMutableSet().apply {
+                if (contains(sectionId)) remove(sectionId) else add(sectionId)
+            }
+            copy(expandedSectionIds = updated).let { it.buildState() }
+        }
+    }
+
+    fun onDismissError() {
+        updateState { copy(errorMessage = null) }
+    }
+
+    fun onCopyAllMetadata(): String = formatAsJson(state.value.metadataEntries)
+
+    fun onShareAllMetadata(): String = formatAsJson(state.value.metadataEntries)
+
+    private fun MetadataUiState.buildState(
+        entries: List<MetadataEntry> = metadataEntries,
+        searchQuery: String = this.searchQuery,
+    ): MetadataUiState {
+        val trimmedQuery = searchQuery.trim()
+        val filteredEntries = if (trimmedQuery.isBlank()) {
+            entries
+        } else {
+            val query = trimmedQuery.lowercase()
+            entries.filter {
+                it.key.lowercase().contains(query) ||
+                    it.value.lowercase().contains(query) ||
+                    it.sourceTag.lowercase().contains(query)
+            }
+        }
+        val grouped = filteredEntries.groupBy { it.sourceTag }
+        val sections = grouped.entries.sortedBy { it.key }.map { (tag, entriesForTag) ->
+            MetadataSectionUiState(
+                id = tag,
+                title = tag,
+                entries = entriesForTag,
+                isExpanded = expandedSectionIds.contains(tag),
             )
         }
+        return copy(
+            isLoading = false,
+            metadataEntries = entries,
+            searchQuery = searchQuery,
+            sections = sections,
+        )
+    }
+
+    private fun formatAsJson(entries: List<MetadataEntry>): String {
+        val payload = JSONArray()
+        entries.forEach { entry ->
+            val item = JSONObject()
+            item.put("key", entry.key)
+            item.put("value", entry.value)
+            item.put("source", entry.sourceTag)
+            payload.put(item)
+        }
+        val envelope = JSONObject()
+        envelope.put("exportedAt", nowLabel())
+        envelope.put("entries", payload)
+        return envelope.toString(2)
+    }
+
+    private fun nowLabel(): String {
+        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+            .withZone(ZoneId.systemDefault())
+        return formatter.format(Instant.now())
     }
 }

--- a/app/src/main/java/com/example/octofit/features/metadata/MetadataViewModelFactory.kt
+++ b/app/src/main/java/com/example/octofit/features/metadata/MetadataViewModelFactory.kt
@@ -1,0 +1,17 @@
+package com.example.octofit.features.metadata
+
+import android.app.Application
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+
+class MetadataViewModelFactory(
+    private val application: Application,
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(MetadataViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return MetadataViewModel(application) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
+    }
+}

--- a/app/src/main/java/com/example/octofit/features/metadata/ui/MetadataScreen.kt
+++ b/app/src/main/java/com/example/octofit/features/metadata/ui/MetadataScreen.kt
@@ -1,0 +1,302 @@
+package com.example.octofit.features.metadata.ui
+
+import android.app.Application
+import android.content.Intent
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts.OpenDocument
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material.icons.filled.FileOpen
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Divider
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ClipboardManager
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.octofit.features.metadata.MetadataSectionUiState
+import com.example.octofit.features.metadata.MetadataUiState
+import com.example.octofit.features.metadata.MetadataViewModel
+import com.example.octofit.features.metadata.MetadataViewModelFactory
+import com.example.octofit.features.metadata.data.MetadataEntry
+
+@Composable
+fun MetadataScreen(
+    viewModel: MetadataViewModel = viewModel(
+        factory = MetadataViewModelFactory(
+            application = LocalContext.current.applicationContext as Application,
+        ),
+    ),
+) {
+    val uiState by viewModel.state.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+    val clipboardManager = LocalClipboardManager.current
+    val picker = rememberLauncherForActivityResult(OpenDocument()) { uri: Uri? ->
+        if (uri != null) {
+            viewModel.onImageSelected(uri)
+        }
+    }
+
+    MetadataContent(
+        uiState = uiState,
+        onPickImage = { picker.launch(arrayOf("image/*")) },
+        onSearchQueryChange = viewModel::onSearchQueryChange,
+        onToggleSection = viewModel::onToggleSection,
+        onDismissError = viewModel::onDismissError,
+        onCopyAllMetadata = {
+            val payload = viewModel.onCopyAllMetadata()
+            clipboardManager.copyToClipboard(payload)
+        },
+        onShareAllMetadata = {
+            val payload = viewModel.onShareAllMetadata()
+            context.startActivity(payload.toShareIntent())
+        },
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun MetadataContent(
+    uiState: MetadataUiState,
+    onPickImage: () -> Unit,
+    onSearchQueryChange: (String) -> Unit,
+    onToggleSection: (String) -> Unit,
+    onDismissError: () -> Unit,
+    onCopyAllMetadata: () -> Unit,
+    onShareAllMetadata: () -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(text = "Image Metadata") },
+                actions = {
+                    IconButton(onClick = onCopyAllMetadata, enabled = uiState.metadataEntries.isNotEmpty()) {
+                        Icon(imageVector = Icons.Default.ContentCopy, contentDescription = "Copy metadata")
+                    }
+                    IconButton(onClick = onShareAllMetadata, enabled = uiState.metadataEntries.isNotEmpty()) {
+                        Icon(imageVector = Icons.Default.Share, contentDescription = "Share metadata")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 20.dp, vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            ElevatedCard(
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Column(
+                    modifier = Modifier.padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    Text(
+                        text = "Select an image to inspect metadata.",
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Button(onClick = onPickImage) {
+                            Icon(imageVector = Icons.Default.FileOpen, contentDescription = null)
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(text = "Choose Image")
+                        }
+                        if (uiState.isLoading) {
+                            Spacer(modifier = Modifier.width(16.dp))
+                            CircularProgressIndicator(modifier = Modifier.height(20.dp))
+                        }
+                    }
+                }
+            }
+
+            OutlinedTextField(
+                value = uiState.searchQuery,
+                onValueChange = onSearchQueryChange,
+                modifier = Modifier.fillMaxWidth(),
+                label = { Text(text = "Search metadata") },
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                singleLine = true,
+                enabled = uiState.metadataEntries.isNotEmpty(),
+            )
+
+            MetadataSections(
+                sections = uiState.sections,
+                onToggleSection = onToggleSection,
+                emptyStateText = if (uiState.metadataEntries.isEmpty()) {
+                    "No metadata loaded yet."
+                } else {
+                    "No metadata matches your search."
+                },
+            )
+        }
+
+        if (uiState.errorMessage != null) {
+            AlertDialog(
+                onDismissRequest = onDismissError,
+                confirmButton = {
+                    TextButton(onClick = onDismissError) {
+                        Text(text = "OK")
+                    }
+                },
+                title = { Text(text = "Metadata error") },
+                text = { Text(text = uiState.errorMessage) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun MetadataSections(
+    sections: List<MetadataSectionUiState>,
+    onToggleSection: (String) -> Unit,
+    emptyStateText: String,
+) {
+    if (sections.isEmpty()) {
+        Box(
+            modifier = Modifier.fillMaxWidth(),
+            contentAlignment = Alignment.CenterStart,
+        ) {
+            Text(
+                text = emptyStateText,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        return
+    }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(bottom = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        items(sections, key = { it.id }) { section ->
+            ElevatedCard(
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    SectionHeader(
+                        title = section.title,
+                        count = section.entries.size,
+                        isExpanded = section.isExpanded,
+                        onToggle = { onToggleSection(section.id) },
+                    )
+                    if (section.isExpanded) {
+                        Divider()
+                        SectionEntries(entries = section.entries)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionHeader(
+    title: String,
+    count: Int,
+    isExpanded: Boolean,
+    onToggle: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(text = title, style = MaterialTheme.typography.titleSmall)
+            Text(
+                text = "$count entries",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        IconButton(onClick = onToggle) {
+            Icon(
+                imageVector = if (isExpanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                contentDescription = if (isExpanded) "Collapse section" else "Expand section",
+            )
+        }
+    }
+}
+
+@Composable
+private fun SectionEntries(
+    entries: List<MetadataEntry>,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        entries.forEach { entry ->
+            Column(modifier = Modifier.fillMaxWidth()) {
+                Text(
+                    text = entry.key,
+                    style = MaterialTheme.typography.labelLarge,
+                )
+                Text(
+                    text = entry.value,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+private fun ClipboardManager.copyToClipboard(value: String) {
+    setText(AnnotatedString(value))
+}
+
+private fun String.toShareIntent(): Intent {
+    val intent = Intent(Intent.ACTION_SEND).apply {
+        type = "text/plain"
+        putExtra(Intent.EXTRA_TEXT, this@toShareIntent)
+    }
+    return Intent.createChooser(intent, "Share metadata")
+}


### PR DESCRIPTION
### Motivation
- Provide a first-class Compose UI for inspecting image metadata instead of the previous placeholder view.
- Allow users to pick images through the platform picker (`OpenDocument`) and safely extract metadata off the main thread.
- Expose view state from a ViewModel so business logic (loading, filtering, grouping, export formatting) stays outside Composables.
- Enable simple export flows (copy/share) for the discovered metadata in a portable JSON/text format.

### Description
- Added a new Compose screen at `features/metadata/ui/MetadataScreen.kt` that uses `rememberLauncherForActivityResult(OpenDocument())` for image selection, shows a search field, and renders expandable sections grouped by metadata source with copy/share actions.  
- Reworked `MetadataUiState` to include `isLoading`, `errorMessage`, `metadataEntries`, `searchQuery`, `sections`, and `expandedSectionIds`, and added `MetadataSectionUiState` to represent sectioned UI.  
- Implemented `MetadataViewModel` to accept `Application`, orchestrate `MetadataExtractor` calls on `viewModelScope`, expose state via the existing `BaseViewModel` flow, support search/filtering, section expansion toggles, error handling, and produce a formatted JSON export for copy/share.  
- Added `MetadataViewModelFactory` for ViewModel creation with `Application`, wired `MainActivity` to launch the new `MetadataScreen`, and kept UI-free of business logic (clipboard/share wrappers live in the UI layer while orchestration remains in the ViewModel).

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e3bb59260832c9dcefb7a5b0b5748)