### PR TITLE
Add AdMob setup and Compose ad wrappers

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,6 +16,34 @@ android {
         versionName = "1.0.0"
     }
 
+    buildTypes {
+        debug {
+            buildConfigField(
+                "String",
+                "ADMOB_BANNER_AD_UNIT_ID",
+                "\"ca-app-pub-3940256099942544/6300978111\"",
+            )
+            buildConfigField(
+                "String",
+                "ADMOB_INTERSTITIAL_AD_UNIT_ID",
+                "\"ca-app-pub-3940256099942544/1033173712\"",
+            )
+            resValue(
+                "string",
+                "admob_app_id",
+                "ca-app-pub-3940256099942544~3347511713",
+            )
+        }
+        release {
+            val admobBannerId = providers.gradleProperty("ADMOB_BANNER_AD_UNIT_ID").orNull.orEmpty()
+            val admobInterstitialId = providers.gradleProperty("ADMOB_INTERSTITIAL_AD_UNIT_ID").orNull.orEmpty()
+            val admobAppId = providers.gradleProperty("ADMOB_APP_ID").orNull.orEmpty()
+            buildConfigField("String", "ADMOB_BANNER_AD_UNIT_ID", "\"$admobBannerId\"")
+            buildConfigField("String", "ADMOB_INTERSTITIAL_AD_UNIT_ID", "\"$admobInterstitialId\"")
+            resValue("string", "admob_app_id", admobAppId)
+        }
+    }
+
     buildFeatures {
         compose = true
     }
@@ -38,6 +66,7 @@ dependencies {
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.exifinterface)
     implementation(libs.metadata.extractor)
+    implementation(libs.play.services.ads)
 
     implementation(libs.kotlinx.coroutines.android)
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,15 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
     <application
+        android:name=".OctofitApplication"
         android:label="@string/app_name"
         android:theme="@style/Theme.Octofit">
+        <meta-data
+            android:name="com.google.android.gms.ads.APPLICATION_ID"
+            android:value="@string/admob_app_id" />
         <activity
             android:name=".MainActivity"
             android:exported="true">

--- a/app/src/main/java/com/example/octofit/OctofitApplication.kt
+++ b/app/src/main/java/com/example/octofit/OctofitApplication.kt
@@ -1,0 +1,11 @@
+package com.example.octofit
+
+import android.app.Application
+import com.example.octofit.features.ads.AdMobInitializer
+
+class OctofitApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        AdMobInitializer.initialize(this)
+    }
+}

--- a/app/src/main/java/com/example/octofit/features/ads/AdMobBanner.kt
+++ b/app/src/main/java/com/example/octofit/features/ads/AdMobBanner.kt
@@ -1,0 +1,78 @@
+package com.example.octofit.features.ads
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import com.google.android.gms.ads.AdListener
+import com.google.android.gms.ads.AdRequest
+import com.google.android.gms.ads.AdSize
+import com.google.android.gms.ads.AdView
+import com.google.android.gms.ads.LoadAdError
+
+@Composable
+fun AdMobBanner(
+    modifier: Modifier = Modifier,
+    adUnitId: String = AdMobConfig.bannerAdUnitId,
+    adSize: AdSize = AdSize.BANNER,
+    onAdLoaded: () -> Unit = {},
+    onAdFailed: (LoadAdError) -> Unit = {},
+) {
+    if (!AdMobConfig.isAdUnitIdConfigured(adUnitId)) {
+        return
+    }
+
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val latestOnAdLoaded by rememberUpdatedState(onAdLoaded)
+    val latestOnAdFailed by rememberUpdatedState(onAdFailed)
+
+    val adViewInstance = remember(adUnitId, adSize) {
+        AdView(context).apply {
+            setAdSize(adSize)
+            this.adUnitId = adUnitId
+            adListener = object : AdListener() {
+                override fun onAdLoaded() {
+                    latestOnAdLoaded()
+                }
+
+                override fun onAdFailedToLoad(error: LoadAdError) {
+                    latestOnAdFailed(error)
+                }
+            }
+        }
+    }
+
+    AndroidView(
+        modifier = modifier,
+        factory = { adViewInstance },
+        update = { adView ->
+            if (!adView.isLoading) {
+                adView.loadAd(AdRequest.Builder().build())
+            }
+        },
+    )
+
+    DisposableEffect(adViewInstance, lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_RESUME -> adViewInstance.resume()
+                Lifecycle.Event.ON_PAUSE -> adViewInstance.pause()
+                Lifecycle.Event.ON_DESTROY -> adViewInstance.destroy()
+                else -> Unit
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+            adViewInstance.destroy()
+        }
+    }
+}

--- a/app/src/main/java/com/example/octofit/features/ads/AdMobConfig.kt
+++ b/app/src/main/java/com/example/octofit/features/ads/AdMobConfig.kt
@@ -1,0 +1,18 @@
+package com.example.octofit.features.ads
+
+import androidx.compose.runtime.Immutable
+import com.example.octofit.BuildConfig
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+@Immutable
+object AdMobConfig {
+    val bannerAdUnitId: String = BuildConfig.ADMOB_BANNER_AD_UNIT_ID
+    val interstitialAdUnitId: String = BuildConfig.ADMOB_INTERSTITIAL_AD_UNIT_ID
+
+    val minInterstitialInterval: Duration = 2.minutes
+    val minLoadInterval: Duration = 30.seconds
+
+    fun isAdUnitIdConfigured(adUnitId: String): Boolean = adUnitId.isNotBlank()
+}

--- a/app/src/main/java/com/example/octofit/features/ads/AdMobInitializer.kt
+++ b/app/src/main/java/com/example/octofit/features/ads/AdMobInitializer.kt
@@ -1,0 +1,19 @@
+package com.example.octofit.features.ads
+
+import android.app.Application
+import android.util.Log
+import com.example.octofit.R
+import com.google.android.gms.ads.MobileAds
+
+object AdMobInitializer {
+    private const val TAG = "AdMobInitializer"
+
+    fun initialize(application: Application) {
+        val appId = application.getString(R.string.admob_app_id)
+        if (appId.isBlank()) {
+            Log.w(TAG, "AdMob app id missing; skipping SDK initialization.")
+            return
+        }
+        MobileAds.initialize(application)
+    }
+}

--- a/app/src/main/java/com/example/octofit/features/ads/AdMobInterstitial.kt
+++ b/app/src/main/java/com/example/octofit/features/ads/AdMobInterstitial.kt
@@ -1,0 +1,141 @@
+package com.example.octofit.features.ads
+
+import android.app.Activity
+import android.content.Context
+import android.os.SystemClock
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import com.google.android.gms.ads.AdError
+import com.google.android.gms.ads.AdRequest
+import com.google.android.gms.ads.FullScreenContentCallback
+import com.google.android.gms.ads.LoadAdError
+import com.google.android.gms.ads.interstitial.InterstitialAd
+import com.google.android.gms.ads.interstitial.InterstitialAdLoadCallback
+import kotlin.time.Duration
+
+@Stable
+class InterstitialAdController internal constructor(
+    private val context: Context,
+    private val adUnitId: String,
+    private val minShowInterval: Duration,
+    private val minLoadInterval: Duration,
+    private val clock: () -> Long = { SystemClock.elapsedRealtime() },
+) {
+    var isAdReady by mutableStateOf(false)
+        private set
+
+    private var interstitialAd: InterstitialAd? = null
+    private var lastShownAt: Long = 0L
+    private var lastLoadAttemptAt: Long = 0L
+
+    fun loadIfNeeded() {
+        if (!AdMobConfig.isAdUnitIdConfigured(adUnitId)) {
+            return
+        }
+        if (interstitialAd != null) {
+            return
+        }
+        val now = clock()
+        if (now - lastLoadAttemptAt < minLoadInterval.inWholeMilliseconds) {
+            return
+        }
+        lastLoadAttemptAt = now
+        InterstitialAd.load(
+            context,
+            adUnitId,
+            AdRequest.Builder().build(),
+            object : InterstitialAdLoadCallback() {
+                override fun onAdLoaded(ad: InterstitialAd) {
+                    interstitialAd = ad
+                    isAdReady = true
+                }
+
+                override fun onAdFailedToLoad(error: LoadAdError) {
+                    interstitialAd = null
+                    isAdReady = false
+                }
+            },
+        )
+    }
+
+    fun showIfReady(
+        activity: Activity,
+        onDismissed: () -> Unit = {},
+        onFailedToShow: (AdError) -> Unit = {},
+    ): Boolean {
+        val ad = interstitialAd ?: return false
+        val now = clock()
+        if (now - lastShownAt < minShowInterval.inWholeMilliseconds) {
+            return false
+        }
+        ad.fullScreenContentCallback = object : FullScreenContentCallback() {
+            override fun onAdDismissedFullScreenContent() {
+                interstitialAd = null
+                isAdReady = false
+                onDismissed()
+                loadIfNeeded()
+            }
+
+            override fun onAdFailedToShowFullScreenContent(error: AdError) {
+                interstitialAd = null
+                isAdReady = false
+                onFailedToShow(error)
+                loadIfNeeded()
+            }
+        }
+        lastShownAt = now
+        isAdReady = false
+        interstitialAd = null
+        ad.show(activity)
+        return true
+    }
+
+    fun dispose() {
+        interstitialAd = null
+        isAdReady = false
+    }
+}
+
+@Composable
+fun rememberInterstitialAdController(
+    adUnitId: String = AdMobConfig.interstitialAdUnitId,
+    minShowInterval: Duration = AdMobConfig.minInterstitialInterval,
+    minLoadInterval: Duration = AdMobConfig.minLoadInterval,
+): InterstitialAdController {
+    val context = LocalContext.current.applicationContext
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val controller = remember(adUnitId, minShowInterval, minLoadInterval) {
+        InterstitialAdController(
+            context = context,
+            adUnitId = adUnitId,
+            minShowInterval = minShowInterval,
+            minLoadInterval = minLoadInterval,
+        )
+    }
+
+    androidx.compose.runtime.DisposableEffect(lifecycleOwner, controller) {
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_START -> controller.loadIfNeeded()
+                Lifecycle.Event.ON_DESTROY -> controller.dispose()
+                else -> Unit
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        controller.loadIfNeeded()
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+            controller.dispose()
+        }
+    }
+
+    return controller
+}

--- a/app/src/main/java/com/example/octofit/features/ads/AdsPolicy.kt
+++ b/app/src/main/java/com/example/octofit/features/ads/AdsPolicy.kt
@@ -1,0 +1,11 @@
+package com.example.octofit.features.ads
+
+/**
+ * Ad policy safeguards for AdMob integration:
+ * - Never block core functionality if ads fail to load or show.
+ * - Only show interstitials in user-initiated flows (e.g., after a completed action).
+ * - Enforce cooldowns between interstitials to avoid rapid repeat impressions.
+ * - Avoid retry loops; loading is throttled via [AdMobConfig.minLoadInterval].
+ * - Use test ad unit IDs in debug builds and real production IDs in release builds.
+ */
+object AdsPolicy

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ composeBom = "2024.10.00"
 coroutines = "1.9.0"
 exif = "1.3.7"
 metadataExtractor = "2.19.0"
+playServicesAds = "23.3.0"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -24,6 +25,7 @@ androidx-activity-compose = { module = "androidx.activity:activity-compose", ver
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 androidx-exifinterface = { module = "androidx.exifinterface:exifinterface", version.ref = "exif" }
 metadata-extractor = { module = "com.drewnoakes:metadata-extractor", version.ref = "metadataExtractor" }
+play-services-ads = { module = "com.google.android.gms:play-services-ads", version.ref = "playServicesAds" }
 
 compose-bom = { module = "androidx.compose:compose-bom", version.ref = "composeBom" }
 compose-ui = { module = "androidx.compose.ui:ui" }


### PR DESCRIPTION
### Motivation
- Provide a dedicated `features/ads` package to encapsulate AdMob integration, keeping ad logic separate from app business logic.
- Initialize the MobileAds SDK at app startup and supply Compose-friendly ad components that are lifecycle-aware and non-blocking.
- Use debug test ad unit IDs by default and allow release builds to inject production IDs through Gradle properties to avoid invalid traffic during development.
- Implement cooldowns and throttling to prevent rapid interstitials and reduce policy risk.

### Description
- Added `play-services-ads` to the version catalog and `implementation(libs.play.services.ads)` to the app module, and introduced build-time fields `ADMOB_BANNER_AD_UNIT_ID`/`ADMOB_INTERSTITIAL_AD_UNIT_ID` and `resValue` for `admob_app_id` in `app/build.gradle.kts` for debug/release handling.
- Registered `OctofitApplication` and added `AdMobInitializer` which reads `@string/admob_app_id` and calls `MobileAds.initialize(...)`, plus required manifest `uses-permission` entries and the `APPLICATION_ID` meta-data in `AndroidManifest.xml`.
- Implemented `AdMobBanner` Compose wrapper that uses `AndroidView` with lifecycle-aware `resume`/`pause`/`destroy` handling and `AdMobInterstitial` with a `InterstitialAdController` and `rememberInterstitialAdController` that throttle loads and shows using `AdMobConfig` timing (`minLoadInterval` / `minInterstitialInterval`).
- Added `AdMobConfig` and `AdsPolicy` to centralize IDs, cooldown defaults, and policy safeguards, and ensured callbacks use `rememberUpdatedState` so Composable lambdas remain safe across recompositions.

### Testing
- No automated tests were executed as part of this change set (CI was not triggered).
- Manual compilation or runtime verification was not performed by automated tooling in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e3fd3f7dc832c8afcca2cee254007)