### PR TITLE
Add SAF privacy notice, per-entry metadata redaction, and Play Console data safety doc

### DIFF
--- a/app/src/main/java/com/example/octofit/features/metadata/MetadataUiState.kt
+++ b/app/src/main/java/com/example/octofit/features/metadata/MetadataUiState.kt
@@ -12,6 +12,7 @@ data class MetadataUiState(
     val searchQuery: String,
     val sections: List<MetadataSectionUiState>,
     val expandedSectionIds: Set<String>,
+    val redactedEntryIds: Set<String>,
 ) : UiState
 
 @Immutable

--- a/app/src/main/java/com/example/octofit/features/metadata/MetadataViewModel.kt
+++ b/app/src/main/java/com/example/octofit/features/metadata/MetadataViewModel.kt
@@ -24,6 +24,7 @@ class MetadataViewModel(
         searchQuery = "",
         sections = emptyList(),
         expandedSectionIds = emptySet(),
+        redactedEntryIds = emptySet(),
     ),
 ) {
     private val extractor = MetadataExtractor(application.applicationContext)
@@ -37,7 +38,7 @@ class MetadataViewModel(
         loadJob = viewModelScope.launch {
             try {
                 val entries = extractor.extract(uri)
-                updateState { buildState(entries = entries) }
+                updateState { buildState(entries = entries, redactedEntryIds = emptySet()) }
             } catch (error: Exception) {
                 updateState {
                     copy(
@@ -70,9 +71,19 @@ class MetadataViewModel(
 
     fun onShareAllMetadata(): String = formatAsJson(state.value.metadataEntries)
 
+    fun onToggleRedaction(entryId: String) {
+        updateState {
+            val updated = redactedEntryIds.toMutableSet().apply {
+                if (contains(entryId)) remove(entryId) else add(entryId)
+            }
+            copy(redactedEntryIds = updated)
+        }
+    }
+
     private fun MetadataUiState.buildState(
         entries: List<MetadataEntry> = metadataEntries,
         searchQuery: String = this.searchQuery,
+        redactedEntryIds: Set<String> = this.redactedEntryIds,
     ): MetadataUiState {
         val trimmedQuery = searchQuery.trim()
         val filteredEntries = if (trimmedQuery.isBlank()) {
@@ -94,17 +105,20 @@ class MetadataViewModel(
                 isExpanded = expandedSectionIds.contains(tag),
             )
         }
+        val validRedactions = redactedEntryIds.intersect(entries.map { it.id }.toSet())
         return copy(
             isLoading = false,
             metadataEntries = entries,
             searchQuery = searchQuery,
             sections = sections,
+            redactedEntryIds = validRedactions,
         )
     }
 
     private fun formatAsJson(entries: List<MetadataEntry>): String {
         val payload = JSONArray()
-        entries.forEach { entry ->
+        val redactions = state.value.redactedEntryIds
+        entries.filterNot { redactions.contains(it.id) }.forEach { entry ->
             val item = JSONObject()
             item.put("key", entry.key)
             item.put("value", entry.value)

--- a/app/src/main/java/com/example/octofit/features/metadata/data/MetadataEntry.kt
+++ b/app/src/main/java/com/example/octofit/features/metadata/data/MetadataEntry.kt
@@ -1,6 +1,7 @@
 package com.example.octofit.features.metadata.data
 
 data class MetadataEntry(
+    val id: String,
     val key: String,
     val value: String,
     val sourceTag: String,

--- a/app/src/main/java/com/example/octofit/features/metadata/data/MetadataExtractor.kt
+++ b/app/src/main/java/com/example/octofit/features/metadata/data/MetadataExtractor.kt
@@ -55,6 +55,7 @@ class MetadataExtractor(
                 exif.getAttribute(tag)?.let { value ->
                     if (value.isNotBlank()) {
                         entries += MetadataEntry(
+                            id = buildEntryId(tag, value, "EXIF:$tag"),
                             key = tag,
                             value = value,
                             sourceTag = "EXIF:$tag",
@@ -101,6 +102,7 @@ class MetadataExtractor(
             val value = safeTagValue(tag)
             if (!value.isNullOrBlank()) {
                 entries += MetadataEntry(
+                    id = buildEntryId(tag.tagName, value, directoryName),
                     key = tag.tagName,
                     value = value,
                     sourceTag = directoryName,
@@ -138,5 +140,9 @@ class MetadataExtractor(
             ExifInterface.TAG_GPS_LONGITUDE,
             ExifInterface.TAG_GPS_ALTITUDE,
         )
+    }
+
+    private fun buildEntryId(key: String, value: String, sourceTag: String): String {
+        return "$sourceTag|$key|$value"
     }
 }

--- a/app/src/main/java/com/example/octofit/features/metadata/ui/MetadataScreen.kt
+++ b/app/src/main/java/com/example/octofit/features/metadata/ui/MetadataScreen.kt
@@ -79,6 +79,7 @@ fun MetadataScreen(
         onPickImage = { picker.launch(arrayOf("image/*")) },
         onSearchQueryChange = viewModel::onSearchQueryChange,
         onToggleSection = viewModel::onToggleSection,
+        onToggleRedaction = viewModel::onToggleRedaction,
         onDismissError = viewModel::onDismissError,
         onCopyAllMetadata = {
             val payload = viewModel.onCopyAllMetadata()
@@ -98,19 +99,23 @@ private fun MetadataContent(
     onPickImage: () -> Unit,
     onSearchQueryChange: (String) -> Unit,
     onToggleSection: (String) -> Unit,
+    onToggleRedaction: (String) -> Unit,
     onDismissError: () -> Unit,
     onCopyAllMetadata: () -> Unit,
     onShareAllMetadata: () -> Unit,
 ) {
+    val hasSharableEntries = uiState.metadataEntries.any { entry ->
+        entry.id !in uiState.redactedEntryIds
+    }
     Scaffold(
         topBar = {
             TopAppBar(
                 title = { Text(text = "Image Metadata") },
                 actions = {
-                    IconButton(onClick = onCopyAllMetadata, enabled = uiState.metadataEntries.isNotEmpty()) {
+                    IconButton(onClick = onCopyAllMetadata, enabled = hasSharableEntries) {
                         Icon(imageVector = Icons.Default.ContentCopy, contentDescription = "Copy metadata")
                     }
-                    IconButton(onClick = onShareAllMetadata, enabled = uiState.metadataEntries.isNotEmpty()) {
+                    IconButton(onClick = onShareAllMetadata, enabled = hasSharableEntries) {
                         Icon(imageVector = Icons.Default.Share, contentDescription = "Share metadata")
                     }
                 },
@@ -151,6 +156,32 @@ private fun MetadataContent(
                 }
             }
 
+            ElevatedCard(
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Column(
+                    modifier = Modifier.padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Text(
+                        text = "Privacy notice",
+                        style = MaterialTheme.typography.titleSmall,
+                    )
+                    Text(
+                        text = "• Images are selected using the system file picker (Storage Access Framework only).",
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    Text(
+                        text = "• Metadata is extracted on-device and stays local unless you copy or share it.",
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    Text(
+                        text = "• Review entries for sensitive data (GPS, device identifiers) and redact before sharing.",
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+            }
+
             OutlinedTextField(
                 value = uiState.searchQuery,
                 onValueChange = onSearchQueryChange,
@@ -164,6 +195,8 @@ private fun MetadataContent(
             MetadataSections(
                 sections = uiState.sections,
                 onToggleSection = onToggleSection,
+                redactedEntryIds = uiState.redactedEntryIds,
+                onToggleRedaction = onToggleRedaction,
                 emptyStateText = if (uiState.metadataEntries.isEmpty()) {
                     "No metadata loaded yet."
                 } else {
@@ -191,6 +224,8 @@ private fun MetadataContent(
 private fun MetadataSections(
     sections: List<MetadataSectionUiState>,
     onToggleSection: (String) -> Unit,
+    redactedEntryIds: Set<String>,
+    onToggleRedaction: (String) -> Unit,
     emptyStateText: String,
 ) {
     if (sections.isEmpty()) {
@@ -225,7 +260,11 @@ private fun MetadataSections(
                     )
                     if (section.isExpanded) {
                         Divider()
-                        SectionEntries(entries = section.entries)
+                        SectionEntries(
+                            entries = section.entries,
+                            redactedEntryIds = redactedEntryIds,
+                            onToggleRedaction = onToggleRedaction,
+                        )
                     }
                 }
             }
@@ -266,6 +305,8 @@ private fun SectionHeader(
 @Composable
 private fun SectionEntries(
     entries: List<MetadataEntry>,
+    redactedEntryIds: Set<String>,
+    onToggleRedaction: (String) -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -274,16 +315,28 @@ private fun SectionEntries(
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         entries.forEach { entry ->
+            val isRedacted = redactedEntryIds.contains(entry.id)
             Column(modifier = Modifier.fillMaxWidth()) {
-                Text(
-                    text = entry.key,
-                    style = MaterialTheme.typography.labelLarge,
-                )
-                Text(
-                    text = entry.value,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = entry.key,
+                            style = MaterialTheme.typography.labelLarge,
+                        )
+                        Text(
+                            text = if (isRedacted) "Redacted" else entry.value,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    TextButton(onClick = { onToggleRedaction(entry.id) }) {
+                        Text(text = if (isRedacted) "Restore" else "Redact")
+                    }
+                }
             }
         }
     }

--- a/docs/data_safety.md
+++ b/docs/data_safety.md
@@ -1,0 +1,34 @@
+# Play Console Data Safety Mapping
+
+This app processes image metadata locally on-device using the Storage Access Framework (SAF). It does **not** request broad storage permissions or upload metadata to a server.
+
+## Data collection & sharing summary
+
+**Collected data:** None. Metadata is processed on-device and only leaves the device when the user explicitly uses the Share action.
+
+**Shared data:** None by default. User-initiated sharing via the system share sheet is optional and controlled by the user.
+
+## Potential metadata fields (review before sharing)
+
+Metadata may include sensitive information depending on the image source. The app surfaces all fields and allows redaction before sharing.
+
+| Metadata source | Example fields | Data Safety category | Notes |
+| --- | --- | --- | --- |
+| EXIF GPS | GPSLatitude, GPSLongitude, GPSAltitude | Location (Precise) | Only present if the photo contains GPS tags. |
+| EXIF Camera | Make, Model, Software | Device or other IDs | Device model/manufacturer (not a unique device ID). |
+| EXIF Timestamps | DateTimeOriginal | Personal info | Timestamp of capture; can be considered sensitive in some contexts. |
+| Embedded tags | Various camera/app tags | Personal info / Device or other IDs | May include app identifiers or device-related strings. |
+
+## Play Console form guidance
+
+- **Data collected:** No.
+- **Data shared:** No (unless the user explicitly shares via the share sheet).
+- **Data processing:** On-device only; no backend.
+- **Data deletion:** Not applicable (no backend storage).
+
+## In-app disclosures
+
+The app shows a privacy notice explaining:
+- SAF-only access (no broad storage permissions).
+- On-device extraction.
+- User review + redaction before sharing.


### PR DESCRIPTION
### Motivation
- Limit storage access to the Storage Access Framework (SAF) workflow and make metadata handling explicit to satisfy least-privilege and Play Store policies. 
- Prevent accidental sharing of sensitive metadata (GPS, device identifiers, timestamps) by letting users review and redact before exporting. 
- Surface an in‑app privacy disclosure so users and reviewers understand on‑device processing and sharing behavior. 
- Provide a Play Console data safety mapping to simplify policy form completion.

### Description
- Add an `id` field to `MetadataEntry` and generate deterministic entry IDs in `MetadataExtractor` using `buildEntryId(key,value,sourceTag)` so entries can be tracked for redaction. 
- Introduce `redactedEntryIds` to `MetadataUiState` and a `onToggleRedaction` action in `MetadataViewModel`, and validate redactions in `buildState` to ignore invalid IDs. 
- Exclude redacted entries from exported payloads by filtering them in `formatAsJson`, and disable copy/share actions when there are no sharable entries. 
- Update the UI (`MetadataScreen`) to add a privacy notice card and per-entry `Redact` / `Restore` controls, and add `docs/data_safety.md` describing the Data Safety mapping and guidance for Play Console submission.

### Testing
- No automated tests were executed as part of this change. 
- The change set was validated via local code inspection and static searches to ensure new symbols are wired into the UI and ViewModel. 
- Manual review ensured redacted entries are filtered from `formatAsJson` and that UI enables/disables copy/share correctly. 
- Recommend running `./gradlew assembleDebug` and adding unit/UI tests for redaction and export behavior before release.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e41642588832c8833096969ace8a6)