### PR TITLE
Add AdMob banner and interstitial trigger on copy

### DIFF
--- a/app/src/main/java/com/example/octofit/features/metadata/ui/MetadataScreen.kt
+++ b/app/src/main/java/com/example/octofit/features/metadata/ui/MetadataScreen.kt
@@ -1,7 +1,10 @@
 package com.example.octofit.features.metadata.ui
 
 import android.app.Application
+import android.app.Activity
+import android.content.Context
 import android.content.Intent
+import android.content.ContextWrapper
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts.OpenDocument
@@ -51,6 +54,8 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.octofit.features.ads.AdMobBanner
+import com.example.octofit.features.ads.rememberInterstitialAdController
 import com.example.octofit.features.metadata.MetadataSectionUiState
 import com.example.octofit.features.metadata.MetadataUiState
 import com.example.octofit.features.metadata.MetadataViewModel
@@ -67,7 +72,9 @@ fun MetadataScreen(
 ) {
     val uiState by viewModel.state.collectAsStateWithLifecycle()
     val context = LocalContext.current
+    val activity = context.findActivity()
     val clipboardManager = LocalClipboardManager.current
+    val interstitialController = rememberInterstitialAdController()
     val picker = rememberLauncherForActivityResult(OpenDocument()) { uri: Uri? ->
         if (uri != null) {
             viewModel.onImageSelected(uri)
@@ -84,6 +91,7 @@ fun MetadataScreen(
         onCopyAllMetadata = {
             val payload = viewModel.onCopyAllMetadata()
             clipboardManager.copyToClipboard(payload)
+            activity?.let { interstitialController.showIfReady(it) }
         },
         onShareAllMetadata = {
             val payload = viewModel.onShareAllMetadata()
@@ -119,6 +127,11 @@ private fun MetadataContent(
                         Icon(imageVector = Icons.Default.Share, contentDescription = "Share metadata")
                     }
                 },
+            )
+        },
+        bottomBar = {
+            AdMobBanner(
+                modifier = Modifier.fillMaxWidth(),
             )
         },
     ) { padding ->
@@ -352,4 +365,15 @@ private fun String.toShareIntent(): Intent {
         putExtra(Intent.EXTRA_TEXT, this@toShareIntent)
     }
     return Intent.createChooser(intent, "Share metadata")
+}
+
+private fun Context.findActivity(): Activity? {
+    var currentContext = this
+    while (currentContext is ContextWrapper) {
+        if (currentContext is Activity) {
+            return currentContext
+        }
+        currentContext = currentContext.baseContext
+    }
+    return null
 }


### PR DESCRIPTION
### Motivation
- Surface a non-blocking banner ad on the metadata screen to enable unobtrusive monetization.
- Offer an interstitial that may be shown opportunistically after a user copies metadata without blocking the core flow.
- Keep ad logic lifecycle-aware and safe for a single-maintainer app by using Compose-friendly controllers.

### Description
- Add `AdMobBanner` as the `Scaffold` `bottomBar` in `MetadataContent` to show a banner ad when configured.
- Wire up `rememberInterstitialAdController()` in `MetadataScreen` and call `showIfReady` after `onCopyAllMetadata` to trigger interstitials only when available.
- Add a `Context.findActivity()` helper to safely resolve the hosting `Activity` required by `InterstitialAdController.showIfReady`.
- Keep behavior guarded by `AdMobConfig` and the controller so core functionality remains available if ads are not configured or fail to load.

### Testing
- No automated tests were executed for this change.
- Local compile/build verification was not run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e2a63f320832ca76e5f4849ee359a)